### PR TITLE
Fix wrong name (Fallarbor Town) on Sandgem Town

### DIFF
--- a/public/overworldRegions.js
+++ b/public/overworldRegions.js
@@ -161,7 +161,7 @@ var overworldRegions = {
     }, {
         "type": "Feature",
         "properties": {
-            "name": "Fallarbor Town",
+            "name": "Sandgem Town",
             "world": "Overworld",
             "Pokémon": {}
         },


### PR DESCRIPTION
For some reason, Sandgem Town is shown as Fallarbor Town. This PR corrects that.